### PR TITLE
fix: 탈퇴 시 providerId 고유값으로 변경

### DIFF
--- a/src/main/java/com/goodluck_buddy/domain/user/service/UserService.java
+++ b/src/main/java/com/goodluck_buddy/domain/user/service/UserService.java
@@ -64,7 +64,8 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
         user.updateNickname("탈퇴한 사용자");
-        userRepository.withdraw(userId, Status.INACTIVATE, "");
+        String deletedProviderId = "deleted-" + userId;
+        userRepository.withdraw(userId, Status.INACTIVATE, deletedProviderId);
     }
 
     public UserResDto.Profile getUserProfile(Long id) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
             scope:
               - email
               - profile
@@ -24,7 +24,7 @@ spring:
             client-id: ${KAKAO_REST_KEY}
             client-secret: ${KAKAO_CLIENT_SECRET}
             authorization-grant-type: authorization_code
-            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             client-name: Kakao
             scope: [ ]
             client-authentication-method: client_secret_post


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth2 redirect URI configuration for Google and Kakao authentication to use dynamic base URLs instead of hardcoded localhost settings, improving deployment flexibility.
  * Enhanced user account withdrawal process with improved identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->